### PR TITLE
No levenshtein

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,15 @@ with the expected data for the percentages of better analogues.
 PLEASE USE either a set of volcano names or a set of volcano numbers to define
 your set of a priori analogues when running PyVOLCANS. Many thanks.
 
+## Analogy matrices
+
+In the original VOLCANS paper, the analogy matrices were calculated in Matlab.
+These initial releases of pyVOLCANS use these pre-calculated matrices.
+This was the quickest way of making VOLCANS results available to users.
+In a future release, we aim to include a Python version of the code that
+calculates the analogies based on volcano characterisics.
+This will make it the method more transparent.
+
 ## Development
 
 ### For developers

--- a/README.md
+++ b/README.md
@@ -44,15 +44,6 @@ It is necessary to have Git installed and on the system path.
 This method adds `pyvolcans` to the virtual environment PATH so that it can be
 used from any directory.
 
-The installation process will include all required dependencies. If you have
-problems installing python-Levenshtein (common on Windows), and are using
-Anaconda Python, you can install it via:
-
-```
-conda install python-Levenshtein
-```
-
-Then re-run the `pip`  command.
 
 ## How to use PyVOLCANS
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ paper was published. These changes are the following:
 
 - Sinabung, Indonesia (261080): (1) lava flows and lahars from the 2013–2018
 eruption are included; and (2) the 2013–2018 eruption is updated to VEI 4
-(GVP, 2013, database version 4.7.4). Please see [Tierz et al. (2019)] (https://doi.org/10.1007/s00445-019-1336-3).
+(GVP, 2013, database version 4.7.4). Please see [Tierz et al. (2019)](https://doi.org/10.1007/s00445-019-1336-3).
 
 - Alutu, Ethiopia (221270): rock type 'Dacite' is removed from the GVP profile
 of Aluto volcano. Please see [Tierz et al., 2020](https://doi.org/10.1029/2020GC009219).

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ of Aluto volcano. Please see [Tierz et al., 2020](https://doi.org/10.1029/2020GC
 - Quetrupillán, Chile (357121): the following rock types are used instead of
 those in the GVP 4.6.7 profile: Major (Trachyte), Minor (Basalt, Basaltic
 andesite, Rhyolite). A crater diameter of 1.37 km (equivalent to the value
-of summit width in [Grosse et al., 2014](https://doi.org/10.1007/s00445-013-0784-4)
+of summit width in [Grosse et al., 2014](https://doi.org/10.1007/s00445-013-0784-4))
 is used for Quetrupillán. Please see [Simmons et al. (2020)](https://doi.org/10.30909/vol.03.01.115137)
 and Simmons (2020).
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Marion Island,South Africa,234070,0.89296
 PyVOLCANS can also be used to investigate sets of analogue volcanoes that have
 been derived using other approaches different from PyVOLCANS, e.g. analogue
 volcanoes based on expert knowledge. Such analogue volcanoes might be called
-'a priori analogues' [Tierz et al., 2019](https://doi.org/10.1007/s00445-019-1336-3).
+'a priori analogues' ([Tierz et al., 2019](https://doi.org/10.1007/s00445-019-1336-3)).
 PyVOLCANS offers the user the possibility of checking for the proportion (or
 percentage) of Holocene volcanoes in the GVP database that are 'better
 analogues' (i.e. have a higher value of total analogy with the target volcano),
@@ -332,11 +332,32 @@ your set of a priori analogues when running PyVOLCANS. Many thanks.
 ## Analogy matrices
 
 In the original VOLCANS paper, the analogy matrices were calculated in Matlab.
-These initial releases of pyVOLCANS use these pre-calculated matrices.
-This was the quickest way of making VOLCANS results available to users.
-In a future release, we aim to include a Python version of the code that
-calculates the analogies based on volcano characterisics.
-This will make it the method more transparent.
+Please note that these matrices are based on data contained in the Volcanoes
+of the World database (GVP) v. 4.6.7 (Tierz et al., 2019).
+
+Please also note that a few minor modifications have been implemented on some
+of the matrices, as a result of research developed since the original VOLCANS
+paper was published. These changes are the following:
+
+- Sinabung, Indonesia (261080): (1) lava flows and lahars from the 2013–2018
+eruption are included; and (2) the 2013–2018 eruption is updated to VEI 4
+(GVP, 2013, database version 4.7.4). Please see [Tierz et al. (2019)] (https://doi.org/10.1007/s00445-019-1336-3).
+
+- Alutu, Ethiopia (221270): rock type 'Dacite' is removed from the GVP profile
+of Aluto volcano. Please see [Tierz et al., 2020](https://doi.org/10.1029/2020GC009219).
+
+- Quetrupillán, Chile (357121): the following rock types are used instead of
+those in the GVP 4.6.7 profile: Major (Trachyte), Minor (Basalt, Basaltic
+andesite, Rhyolite). A crater diameter of 1.37 km (equivalent to the value
+of summit width in [Grosse et al., 2014](https://doi.org/10.1007/s00445-013-0784-4)
+is used for Quetrupillán. Please see [Simmons et al. (2020)](https://doi.org/10.30909/vol.03.01.115137)
+and Simmons (2020).
+
+The initial releases of PyVOLCANS make use these pre-calculated analogy
+matrices. This was the quickest way of making VOLCANS results available
+to users. In a future release, we aim to include a Python version of the
+code that calculates the analogies based on volcano characterisics.
+This will make the method more transparent.
 
 ## Development
 

--- a/pyvolcans/VOLCANS_mat_files/base.py
+++ b/pyvolcans/VOLCANS_mat_files/base.py
@@ -1,7 +1,7 @@
 """
 Created on Thu Oct 15 12:48:00 2020
 
-@author: Vyron Christodoulou, John A. Stevenson, Pablo Tierz  
+@author: Vyron Christodoulou, John A. Stevenson, Pablo Tierz
          (British Geological Survey, The Lyell Centre,
          Edinburgh, UK).
 """
@@ -10,25 +10,29 @@ from pathlib import Path
 from pymatreader import read_mat
 
 BASE_DIR = Path(__file__).resolve().parent
-DIRNAME_ANALOGY= BASE_DIR.joinpath("analogy_mats")
-DIRNAME_VOLCANO= BASE_DIR.joinpath("VOTW_prepared_data")
+DIRNAME_ANALOGY = BASE_DIR.joinpath("analogy_mats")
+DIRNAME_VOLCANO = BASE_DIR.joinpath("VOTW_prepared_data")
 
 
 def load_tectonic_analogy():
     return read_mat(DIRNAME_ANALOGY.joinpath("ATfinal_allvolcs.mat"))["AT_allcross"]
 
+
 def load_geochemistry_analogy():
     return read_mat(DIRNAME_ANALOGY.joinpath("AGfinal_allvolcs_ALU_QUET.mat"))["AG_allcross"]
+
 
 def load_morphology_analogy():
     return read_mat(DIRNAME_ANALOGY.joinpath("AMfinal_allvolcs_QUET.mat"))["AM_allcross"]
 
+
 def load_eruption_size_analogy():
     return read_mat(DIRNAME_ANALOGY.joinpath("ASzfinal_allvolcs_SINA.mat"))["ASz_allcross"]
+
 
 def load_eruption_style_analogy():
     return read_mat(DIRNAME_ANALOGY.joinpath("AStfinal_allvolcs_SINA.mat"))["ASt_allcross"]
 
-def load_volcano_names():
-    return pd.read_csv(DIRNAME_VOLCANO.joinpath("volc_names.csv"), header = None)
 
+def load_volcano_names():
+    return pd.read_csv(DIRNAME_VOLCANO.joinpath("volc_names.csv"), header=None)

--- a/pyvolcans/__init__.py
+++ b/pyvolcans/__init__.py
@@ -31,6 +31,7 @@
     expert-derived analogue volcanoes. Please see Tierz et al. (2019) for more
     details on the VOLCANS method (https://doi.org/10.1007/s00445-019-1336-3).
 """
+# flake8: noqa
 
 from ._version import get_versions
 __version__ = get_versions()['version']
@@ -42,4 +43,3 @@ from pyvolcans.VOLCANS_mat_files.base import load_geochemistry_analogy
 from pyvolcans.VOLCANS_mat_files.base import load_morphology_analogy
 from pyvolcans.VOLCANS_mat_files.base import load_eruption_style_analogy
 from pyvolcans.VOLCANS_mat_files.base import load_eruption_size_analogy
-

--- a/pyvolcans/pyvolcans.py
+++ b/pyvolcans/pyvolcans.py
@@ -206,31 +206,25 @@ def parse_args():
                         help="Provide one or more a priori analogue volcanoes",
                         default=None)
     parser.add_argument("-Ts", "--tectonic_setting", action='append',
-                        help=
-                        "Set tectonic setting weight (e.g. '0.2' or '1/5')",
+                        help="Set tectonic setting weight (e.g. '0.2' or '1/5')",
                         default=None, type=str)
     parser.add_argument("-G", "--rock_geochemistry", action='append',
-                        help=
-                        "Set rock geochemistry weight (e.g. '0.2' or '1/5')",
+                        help="Set rock geochemistry weight (e.g. '0.2' or '1/5')",
                         default=None, type=str)
     parser.add_argument("-M", "--morphology", action='append',
-                        help=
-                        "Set volcano morphology weight (e.g. '0.2' or '1/5')",
+                        help="Set volcano morphology weight (e.g. '0.2' or '1/5')",
                         default=None, type=str)
     parser.add_argument("-Sz", "--eruption_size", action='append',
-                        help=
-                        "Set eruption size weight (e.g. '0.2' or '1/5')",
+                        help="Set eruption size weight (e.g. '0.2' or '1/5')",
                         default=None, type=str)
     parser.add_argument("-St", "--eruption_style", action='append',
-                        help=
-                        "Set eruption style weight (e.g. '0.2' or '1/5')",
+                        help="Set eruption style weight (e.g. '0.2' or '1/5')",
                         default=None, type=str)
     parser.add_argument("--count",
                         help="Set the number of top analogue volcanoes",
                         default='10', type=int)
     parser.add_argument("-w", "--write_csv_file", action="store_true",
-                        help=
-                        "Write list of top analogue volcanoes as .csv file")
+                        help="Write list of top analogue volcanoes as .csv file")
     parser.add_argument("-W", "--website", action="store_true",
                         help="Open GVP website for top analogue volcano")
     parser.add_argument("-v", "--verbose", action="store_true",
@@ -245,6 +239,7 @@ def parse_args():
     args = parser.parse_args()
 
     return args
+
 
 if __name__ == '__main__':
     cli()

--- a/pyvolcans/pyvolcans_func.py
+++ b/pyvolcans/pyvolcans_func.py
@@ -23,7 +23,7 @@ from pyvolcans import (load_tectonic_analogy,
                        load_volcano_names)
 
 # fuzzywuzzy would like to use a sequence matcher provided by the
-# Python-Levenshtein package, but this has dependencies the require
+# Python-Levenshtein package, but this has dependencies that require
 # compilation.  When it is not installed, it uses the matcher provided
 # by the standard library difflib and raises a warning.  In our case
 # it doesn't make much difference so we suppress the warning.

--- a/pyvolcans/pyvolcans_func.py
+++ b/pyvolcans/pyvolcans_func.py
@@ -1,22 +1,19 @@
 # -*- coding: utf-8 -*-
 """
+Set of functions related to the implementation of PyVOLCANS
+
 Created on Tue Mar  3 09:49:16 2020
 
 @author: Pablo Tierz, John A. Stevenson, Vyron Christodoulou
          (British Geological Survey, The Lyell Centre,
          Edinburgh, UK).
 """
-
-# Set of functions related to the implementation of PyVOLCANS
-
-# standard packages
+import warnings
 import webbrowser
 from fractions import Fraction
 
 # external packages
 import numpy as np
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
 
 from pyvolcans import (load_tectonic_analogy,
                        load_geochemistry_analogy,
@@ -24,6 +21,16 @@ from pyvolcans import (load_tectonic_analogy,
                        load_eruption_size_analogy,
                        load_eruption_style_analogy,
                        load_volcano_names)
+
+# fuzzywuzzy would like to use a sequence matcher provided by the
+# Python-Levenshtein package, but this has dependencies the require
+# compilation.  When it is not installed, it uses the matcher provided
+# by the standard library difflib and raises a warning.  In our case
+# it doesn't make much difference so we suppress the warning.
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore',
+                            message="Using slow pure-python SequenceMatcher.")
+    from fuzzywuzzy import fuzz, process
 
 VOLCANO_NAMES = load_volcano_names()
 
@@ -112,14 +119,14 @@ def fuzzy_matching(volcano_name, limit=10):
     similar_volcano_names : str
         List of volcanoes with similar names to the target volcano
     """
-
     matches = process.extract(volcano_name, VOLCANO_NAMES[0], limit=limit,
                               scorer=fuzz.UQRatio)
+
     match_idx = [item[2] for item in matches]
     volcano_info = \
-        VOLCANO_NAMES.iloc[match_idx].rename(columns={0:'name',
-                                                      1:'country',
-                                                      2:'smithsonian_id'})
+        VOLCANO_NAMES.iloc[match_idx].rename(columns={0: 'name',
+                                                      1: 'country',
+                                                      2: 'smithsonian_id'})
     similar_volcano_names = volcano_info.to_string(index=False)
 
     return similar_volcano_names

--- a/pyvolcans/pyvolcans_func.py
+++ b/pyvolcans/pyvolcans_func.py
@@ -384,17 +384,17 @@ def calculate_weighted_analogy_matrix(my_volcano, weights,
     volcans_result = VOLCANO_NAMES.copy()
     volcans_result.columns = ['name', 'country', 'smithsonian_id']
     volcans_result['total_analogy'] = \
-        weighted_total_analogy_matrix[volcano_idx,]
+        weighted_total_analogy_matrix[volcano_idx, ]
     volcans_result['ATs'] = \
-        weighted_tectonic_analogy[volcano_idx,]
+        weighted_tectonic_analogy[volcano_idx, ]
     volcans_result['AG'] = \
-        weighted_geochemistry_analogy[volcano_idx,]
+        weighted_geochemistry_analogy[volcano_idx, ]
     volcans_result['AM'] = \
-        weighted_morphology_analogy[volcano_idx,]
+        weighted_morphology_analogy[volcano_idx, ]
     volcans_result['ASz'] = \
-        weighted_eruption_size_analogy[volcano_idx,]
+        weighted_eruption_size_analogy[volcano_idx, ]
     volcans_result['ASt'] = \
-        weighted_eruption_style_analogy[volcano_idx,]
+        weighted_eruption_style_analogy[volcano_idx, ]
 
     return volcans_result
 
@@ -510,7 +510,7 @@ def open_gvp_website(top_analogue_vnum):
     """
 
     my_web = f'https://volcano.si.edu/volcano.cfm?vn={top_analogue_vnum}' \
-              '&vtab=GeneralInfo'  # Open the General Info tab
+        '&vtab=GeneralInfo'  # Open the General Info tab
     browser_opened = webbrowser.open(my_web)
 
     if not browser_opened:
@@ -674,10 +674,11 @@ def get_analogy_percentile(my_volcano, apriori_volcano,
                                         interpolation='midpoint')
     # find the closest value to the analogy of the a priori volcano
     # NOTE that this value already represents the percentile (0-100)
-    my_percentile = (np.abs(analogy_percentiles - \
+    my_percentile = (np.abs(analogy_percentiles -
                             my_analogy_values[apriori_volcano_idx])).argmin()
 
     return my_percentile
+
 
 def get_many_analogy_percentiles(my_volcano, apriori_volcanoes_list,
                                  volcans_result):
@@ -736,7 +737,7 @@ def get_many_analogy_percentiles(my_volcano, apriori_volcanoes_list,
     # create empty dictionaries for percentiles
     # and percentage of better analogues
     percentile_dictionary = {}
-    better_analogues_dictionary = {} # 100-percentile
+    better_analogues_dictionary = {}  # 100-percentile
 
     # loop over get_analogy_percentile
     for volcano in apriori_volcanoes_list:
@@ -762,7 +763,7 @@ def get_many_analogy_percentiles(my_volcano, apriori_volcanoes_list,
             name_to_print = volcano
 
         vnum_to_print = \
-                volcans_result['smithsonian_id'].iloc[volcano_idx_to_print]
+            volcans_result['smithsonian_id'].iloc[volcano_idx_to_print]
         print(f'{name_to_print} ({vnum_to_print}): {percentage}%\n')
 
     return percentile_dictionary, better_analogues_dictionary

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ fuzzywuzzy
 numpy
 pandas
 pymatreader
-python-Levenshtein
 scipy
 
 # Development tools

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'numpy',
         'pandas',
         'pymatreader',
-        'python-Levenshtein',
         'scipy'
     ],
     extras_require={

--- a/test/test_pyvolcans.py
+++ b/test/test_pyvolcans.py
@@ -123,74 +123,34 @@ def mock_analogies():
     return mock_analogies
 
 
-@pytest.mark.parametrize("weights,expected",
-                        [({'tectonic_setting': 0,
-                         'geochemistry': 0.25,
-                         'morphology': 0.25,
-                         'eruption_size': 0.25,
-                         'eruption_style': 0.25}, 1111)])
+@pytest.mark.parametrize("weights, expected", [
+    ({'tectonic_setting': 0,
+      'geochemistry': 0.25,
+      'morphology': 0.25,
+      'eruption_size': 0.25,
+      'eruption_style': 0.25}, 1111),
+    ({'tectonic_setting': 0.25,
+      'geochemistry': 0,
+      'morphology': 0.25,
+      'eruption_size': 0.25,
+      'eruption_style': 0.25}, 10111),
+    ({'tectonic_setting': 0.25,
+      'geochemistry': 0.25,
+      'morphology': 0,
+      'eruption_size': 0.25,
+      'eruption_style': 0.25}, 11011),
+    ({'tectonic_setting': 0.25,
+      'geochemistry': 0.25,
+      'morphology': 0.25,
+      'eruption_size': 0,
+      'eruption_style': 0.25}, 11101),
+    ({'tectonic_setting': 0.25,
+      'geochemistry': 0.25,
+      'morphology': 0.25,
+      'eruption_size': 0.25,
+      'eruption_style': 0}, 11110)
+   ])
 def test_combined_analogy_matrix_no_tectonic(weights, expected, mock_analogies): 
-    pandas_df = calculate_weighted_analogy_matrix(
-            'West Eifel Volcanic Field', weights, mock_analogies)
-    matrix = pandas_df.loc[get_volcano_idx_from_name(
-            'West Eifel Volcanic Field'),
-            'total_analogy']
-    assert matrix.astype(int) == expected
-
-
-@pytest.mark.parametrize("weights,expected",
-                        [({'tectonic_setting': 0.25,
-                           'geochemistry': 0,
-                           'morphology': 0.25,
-                           'eruption_size': 0.25,
-                           'eruption_style': 0.25}, 10111)])
-def test_combined_analogy_matrix_no_geochemistry(weights, expected, mock_analogies):
-    pandas_df = calculate_weighted_analogy_matrix(
-            'West Eifel Volcanic Field', weights, mock_analogies)
-    matrix = pandas_df.loc[get_volcano_idx_from_name(
-            'West Eifel Volcanic Field'),
-            'total_analogy']
-    assert matrix.astype(int) == expected
-
-
-@pytest.mark.parametrize("weights,expected", 
-                       [({'tectonic_setting':0.25,
-                          'geochemistry': 0.25,
-                          'morphology': 0,
-                          'eruption_size': 0.25,
-                          'eruption_style': 0.25}, 11011)])
-def test_combined_analogy_matrix_no_morphology(weights, expected, mock_analogies):
-    pandas_df = calculate_weighted_analogy_matrix(
-            'West Eifel Volcanic Field', weights, mock_analogies)
-    matrix = pandas_df.loc[get_volcano_idx_from_name(
-            'West Eifel Volcanic Field'),
-            'total_analogy']
-    assert matrix.astype(int) == expected
-
-
-@pytest.mark.parametrize("weights,expected",
-                        [({'tectonic_setting':0.25,
-                           'geochemistry': 0.25,
-                           'morphology': 0.25,
-                           'eruption_size': 0,
-                           'eruption_style': 0.25}, 11101)])
-
-def test_combined_analogy_matrix_no_eruption_size(weights, expected, mock_analogies):
-    pandas_df = calculate_weighted_analogy_matrix(
-            'West Eifel Volcanic Field', weights, mock_analogies)
-    matrix = pandas_df.loc[get_volcano_idx_from_name(
-            'West Eifel Volcanic Field'),
-            'total_analogy']
-    assert matrix.astype(int) == expected
-
-
-@pytest.mark.parametrize("weights,expected",
-                        [({'tectonic_setting':0.25,
-                           'geochemistry': 0.25,
-                           'morphology': 0.25,
-                           'eruption_size': 0.25,
-                           'eruption_style': 0}, 11110)])
-def test_combined_analogy_matrix_no_eruption_style(weights, expected, mock_analogies):
     pandas_df = calculate_weighted_analogy_matrix(
             'West Eifel Volcanic Field', weights, mock_analogies)
     matrix = pandas_df.loc[get_volcano_idx_from_name(

--- a/test/test_pyvolcans.py
+++ b/test/test_pyvolcans.py
@@ -2,7 +2,7 @@
 """
 Created on Fri May 15 12:49:55 2020
 
-@author: Vyron Christodoulou, John A. Stevenson, Pablo Tierz  
+@author: Vyron Christodoulou, John A. Stevenson, Pablo Tierz
          (British Geological Survey, The Lyell Centre,
          Edinburgh, UK).
 """
@@ -25,6 +25,7 @@ from pyvolcans.pyvolcans_func import (
 )
 
 # pylint: disable=missing-docstring
+
 
 def test_volcano_idx():
     idx = get_volcano_idx_from_name(volcano_name='Fuego')
@@ -104,7 +105,7 @@ def test_volcano_idx_from_number():
 @pytest.mark.parametrize("name,expected", [('blah', 'not found'), ('Santa Isabel', 'not unique')])
 def test_match_name(name, expected):
     with pytest.raises(PyvolcansError) as excinfo:
-         matched = match_name(name)
+        match_name(name)
     assert expected in str(excinfo.value)
 
 
@@ -119,7 +120,7 @@ def mock_analogies():
                       'geochemistry': np.array([4000]),
                       'morphology': np.array([400]),
                       'eruption_size': np.array([40]),
-                      'eruption_style': np.array([4])}   
+                      'eruption_style': np.array([4])}
     return mock_analogies
 
 
@@ -150,7 +151,7 @@ def mock_analogies():
       'eruption_size': 0.25,
       'eruption_style': 0}, 11110)
    ])
-def test_combined_analogy_matrix_no_tectonic(weights, expected, mock_analogies): 
+def test_combined_analogy_matrix_no_tectonic(weights, expected, mock_analogies):
     pandas_df = calculate_weighted_analogy_matrix(
             'West Eifel Volcanic Field', weights, mock_analogies)
     matrix = pandas_df.loc[get_volcano_idx_from_name(
@@ -174,4 +175,5 @@ def test_open_gvp_website(monkeypatch):
         open_gvp_website(123456)
 
     # Assert
-    assert str(exc_info.value) == "No suitable browser to open https://volcano.si.edu/volcano.cfm?vn=123456&vtab=GeneralInfo"
+    msg = "No suitable browser to open https://volcano.si.edu/volcano.cfm?vn=123456&vtab=GeneralInfo"
+    assert str(exc_info.value) == msg

--- a/test/test_pyvolcans.py
+++ b/test/test_pyvolcans.py
@@ -38,12 +38,11 @@ def test_volcano_name():
 
 def test_fuzzy_matching():
     volc_matches = fuzzy_matching('West Eifel')
-    assert isinstance(volc_matches, str)
-    assert len(volc_matches) == 681
     assert 'West Eifel Volcanic Field' in volc_matches
-    volc_matches_limit = fuzzy_matching('West Eiffel', limit=2)
-    assert len(volc_matches_limit) == 161
-    assert 'West Eifel Volcanic Field' in volc_matches
+
+    # Test with limit
+    volc_matches_limit = fuzzy_matching('West Eiffel', limit=3)
+    assert 'West Eifel Volcanic Field' in volc_matches_limit
 
 
 def test_volcano_number():


### PR DESCRIPTION
### Description

This merge request removes the Python-Levenshtein dependency from the fuzzy matching.  In theory, this makes it slower but I can't tell the difference.  Without this dependency, which needs to be compiled locally when installed via pip, the install of pyvolcans is easier.  fuzzywuzzy complains if the dependency is missing so we have to suppress the warning.

I have also added a note about pre-compiled analogy tables and made Flake8 fixes.  The Flake8 fixes will complicate the diff, so it will be easier to see changes by checking individual commits.

### To test

Install in a fresh virtual environment by checking out this branch and running `python -m pip install -e .[dev]`

+ [x] Confirm that all tests pass
+ [x] Run some bad volcano names e.g. Hokla and confirm that no error message is shown