### PR TITLE
Add Github Actions CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,22 +24,3 @@ jobs:
      
       - name: Run tests
         run: python -m pytest -vs
-
-      - name: Install pypa/build
-        run: pip install build
-
-      - name: Build a binary wheel and a source tarball
-        run: >-
-             python -m
-             build
-             --sdist
-             --wheel
-             --outdir dist/
-
-      - name: Publish to Pypi
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-         user: __token__
-         password: ${{ secrets.TEST_PYPI_API_PASS }}
-         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
           python-version: 3.8
        
       - name: Install dependencies
-        run: pip install pytest
+        run: |
+             pip install -r requirements
+             pip install pytest
      
       - name: Run tests
         run: python -m pytest -vs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,22 @@ jobs:
      
       - name: Run tests
         run: python -m pytest -vs
+
+      - name: Install pypa/build
+        run: pip install build
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+             python -m
+             build
+             --sdist
+             --wheel
+             --outdir dist/
+
+      - name: Publish to Pypi
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+         user: __token__
+         password: ${{ secrets.TEST_PYPI_API_PASS }}
+         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: pip install build
 
       - name: Build a binary wheel and a source tarball
-        run: |
+        run: >-
              python -m
              build
              --sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
       - main
 jobs:
     test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
+      name: Test
+      runs-on: ubuntu-latest
+      steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.6
        
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
        
       - name: Install dependencies
         run: |
-             pip install -r requirements
+             pip install -r requirements.txt
              pip install pytest
      
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI for pyvolcans
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+    test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+       
+      - name: Install dependencies
+        run: pip install pytest
+     
+      - name: Run tests
+        run: python -m pytest -vs

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,6 +2,7 @@ name: Upload package to Pypi
 
 on:
   release:
+    types: [created]
 
 jobs:
   build-and-publish:
@@ -28,7 +29,6 @@ jobs:
         --outdir dist/
         .
     - name: Publish to Pypi
-      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
        user: __token__

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,37 @@
+name: Upload package to Pypi
+
+on:
+  release:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+   
+    - name: Checkout repository 
+      uses: actions/checkout@v2
+ 
+    - name: Setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install dependencies
+      run: pip install build
+
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish to Pypi
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+       user: __token__
+       password: ${{ secrets.TEST_PYPI_API_PASS }}
+       repository_url: https://test.pypi.org/legacy/
+


### PR DESCRIPTION
## Description

This PR adds two CI/CD workflows based on Github Actions.  

The first, covers setting up the environment, installing the dependencies and testing stages that run every time a PR or a push to the main branch occurs. A linting stage can also be implemented but it's not added here.

The second, covers the publishing of pyvolcans. It installs any dependencies, builds the package and publishes it every time a release is created from the github GUI. 

Finally, because for testing purposes the workflow publishes the package to testpypi; lines  [35-36](https://github.com/BritishGeologicalSurvey/pyvolcans/compare/main...mobiuscreek:main#diff-75e8bbdd253f4a71a14114808840e63b6a9c23529499687d148025d860336504R35-R36) have to be amended, in order to publish the package to pypi.  


