### PR TITLE
Change default fuzzy matching function to token_sort_ratio

### DIFF
--- a/pyvolcans/pyvolcans_func.py
+++ b/pyvolcans/pyvolcans_func.py
@@ -121,7 +121,7 @@ def fuzzy_matching(volcano_name, limit=10):
         List of volcanoes with similar names to the target volcano
     """
     matches = process.extract(volcano_name, VOLCANO_NAMES[0], limit=limit,
-                              scorer=fuzz.UQRatio)
+                              scorer=fuzz.token_sort_ratio)
 
     match_idx = [item[2] for item in matches]
     volcano_info = \


### PR DESCRIPTION
Changes in this branch are targeted to fix Issue #11, raised by @jifarquharson (many thanks for your comments!), regarding the outputs from the `fuzzy_matching()` function. By using the function `fuzz.token_sort_ratio()` in [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy/blob/master/fuzzywuzzy/fuzz.py) to derive the most similar volcano names to the one introduced by the `PyVOLCANS` user (in case the introduced name does not match one in the list of all volcano names in GVP), the mismatching issues described in #11 are not observed anymore.