### PR TITLE
Update deprecated fuzzy matching package 

### DIFF
--- a/pyvolcans/pyvolcans_func.py
+++ b/pyvolcans/pyvolcans_func.py
@@ -36,7 +36,7 @@ def _format_pyvolcans_warning(message, *args, **kwargs):
 # Replace built-in warning format function
 warnings.formatwarning = _format_pyvolcans_warning
 
-# fuzzywuzzy would like to use a sequence matcher provided by the
+# thefuzz would like to use a sequence matcher provided by the
 # Python-Levenshtein package, but this has dependencies that require
 # compilation.  When it is not installed, it uses the matcher provided
 # by the standard library difflib and raises a warning.  In our case
@@ -44,7 +44,7 @@ warnings.formatwarning = _format_pyvolcans_warning
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore',
                             message="Using slow pure-python SequenceMatcher.")
-    from fuzzywuzzy import fuzz, process
+    from thefuzz import fuzz, process
 
 VOLCANO_NAMES = load_volcano_names()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # Required for pyvolcans
-fuzzywuzzy
 numpy
 pandas
 pymatreader
 matplotlib
+thefuzz
 
 # Development tools
 flake8

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(
     packages=["pyvolcans"],
     include_package_data=True,
     install_requires=[
-        'fuzzywuzzy',
         'numpy',
         'pandas',
         'pymatreader',
         'matplotlib',
+        'thefuzz'
     ],
     extras_require={
         'dev': ['flake8',


### PR DESCRIPTION
## Summary

This PR updates the required dependencies with the [thefuzz](https://github.com/seatgeek/thefuzz) package as the previous fuzzy matching package has been deprecated. It addresses issue #14.