### PR TITLE
Paper formatting

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -91,7 +91,8 @@ school={University of Edinburgh}
   author = {{Global Volcanism Program}},
   title = {{Volcanoes of the World, v. 4.10.0 (14 May 2021)}},
   year = {2013},
-  publisher = {Venzke, E (ed.). Smithsonian Institution. Downloaded 09 Jun 2021. \url{https://doi.org/10.5479/si.GVP.VOTW4-2013}}
+  publisher = {Smithsonian Institution},
+  url={https://doi.org/10.5479/si.GVP.VOTW4-2013}
 }
 
 @article{Marzocchi:2021,

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -7,7 +7,7 @@
   pages={e2020GC009219},
   year={2020},
   publisher={Wiley Online Library},
-  url={https://doi.org/10.1029/2020GC009219}
+  doi={10.1029/2020GC009219}
 }
 
 @article{Tierz:2019,
@@ -19,7 +19,7 @@
   pages={76},
   year={2019},
   publisher={Springer},
-  url={https://doi.org/10.1007/s00445-019-1336-3}
+  doi={10.1007/s00445-019-1336-3}
 }
 
 @mastersthesis{White:2020,
@@ -34,7 +34,7 @@ school={University of Edinburgh}
   author={Loughlin, Susan C and Sparks, Steve and Brown, Sarah K and Vye-Brown, Charlotte and Jenkins, Susanna F},
   year={2015},
   publisher={Cambridge University Press},
-  url={https://doi.org/10.1017/CBO9781316276273}
+  doi={10.1017/CBO9781316276273}
 }
 
 @article{Newhall:2002,
@@ -46,7 +46,7 @@ school={University of Edinburgh}
   pages={3--20},
   year={2002},
   publisher={Springer},
-  url={https://doi.org/10.1007/s004450100173}
+  doi={10.1007/s004450100173}
 }
 
 @article{Newhall:2017,
@@ -57,7 +57,7 @@ school={University of Edinburgh}
   pages={184--199},
   year={2017},
   publisher={Elsevier},
-  url={https://doi.org/10.1016/j.jvolgeores.2017.08.003}
+  doi={10.1016/j.jvolgeores.2017.08.003}
 }
 
 @article{Cashman:2014,
@@ -68,7 +68,7 @@ school={University of Edinburgh}
   pages={28},
   year={2014},
   publisher={Frontiers},
-  url={https://doi.org/10.3389/feart.2014.00028}
+  doi={10.3389/feart.2014.00028}
 }
 
 @phdthesis{Simmons:2021,
@@ -76,7 +76,7 @@ school={University of Edinburgh}
   author={Isla Simmons},
   year={2021},
   school={University of Edinburgh},
-  url={https://doi.org/10.7488/era/1087}
+  doi={10.7488/era/1087}
 }
 
 @book{Siebert:2010,
@@ -92,7 +92,7 @@ school={University of Edinburgh}
   title = {{Volcanoes of the World, v. 4.10.0 (14 May 2021)}},
   year = {2013},
   publisher = {Smithsonian Institution},
-  url={https://doi.org/10.5479/si.GVP.VOTW4-2013}
+  doi={10.5479/si.GVP.VOTW4-2013}
 }
 
 @article{Marzocchi:2021,
@@ -104,7 +104,7 @@ school={University of Edinburgh}
   pages={3509--3517},
   year={2021},
   publisher={Copernicus GmbH},
-  url={https://doi.org/10.5194/nhess-21-3509-2021}
+  doi={10.5194/nhess-21-3509-2021}
 }
 
 @incollection{Papale:2021,
@@ -114,6 +114,6 @@ school={University of Edinburgh}
   pages={1--24},
   year={2021},
   publisher={Elsevier},
-  url={https://doi.org/10.1016/B978-0-12-818082-2.00001-9}
+  doi={10.1016/B978-0-12-818082-2.00001-9}
 }
 


### PR DESCRIPTION
This PR updates the formatting of the "Volcanoes of the World" citation and should also help fix some of the missing DOIs whedon was noticing. Several other minor questions and suggestions related to the paper and bibliography are below.

Is there a DOI or URL to accompany the *White (2020)* citation? It is currently the only reference included with no DOI. 

Few comments and suggestions for the paper itself:

- The final sentence of the "Summary" section (lines 28-29) is: "Such methods have been used for many years but we have created the first tool to enable a structured and harmonised approach worldwide." I would consider changing this sentence to something like: "Such methods have been used for many years, here we present the first tool enabling a structured and harmonised approach to be applied worldwide." or similar. This is just a suggestion to move to a more present / active phrasing here.
- I understand why the link to the tweet is provided (lines 40-41), however I am a bit hesitant about keeping it in the final version of the paper as it does not resolve to a DOI and is subject to change or not resolve to anything in the future. I think the point can be made by extending the sentence to provide an example of how it might be used in the classroom or for outreach.
- Similarly, I would suggest removing the link to the Volcanoes of the World Database (line 44) as the included reference points users to that database via a stable DOI
- Unsurprisingly, I have similar reservations about the YouTube link in line 57 and the RiftVolc project link on line 60. I think these links and external data are useful and helpful to the user, but I would suggest including them in the Readme or the documentation for the project rather than embedding potentially unstable links in the paper itself as you can update the links in the project documentation but will be unable to modify the paper itself once published
- I suggest modifying the sentence on line 52 to make it more simple. Rather than date the paper, it might be more straightforward to say something like: "The results from the VOLCANS study have been used in research to explore volcanological factors that influence ...". That suggestion aside, I do not think it is grammatically proper to use "e.g." outside of a parenthetical statement, so I recommend changing the structure of the sentence.


Feel free to merge this PR or close it and incorporate the minor change in your own commit/PR. 

Relates to https://github.com/openjournals/joss-reviews/issues/3649